### PR TITLE
Make it possible to set a custom mqtt clientId in VrpcAgent, too

### DIFF
--- a/vrpc/VrpcAgent.js
+++ b/vrpc/VrpcAgent.js
@@ -163,7 +163,7 @@ class VrpcAgent extends EventEmitter {
    * @return {Promise} Resolves once connected or explicitly ended, never
    * rejects
    */
-  async serve () {
+  async serve (mqttClientId = null) {
     const md5 = crypto
       .createHash('md5')
       .update(this._domain + this._agent)
@@ -183,7 +183,7 @@ class VrpcAgent extends EventEmitter {
       password,
       keepalive: 30,
       connectTimeout: 10 * 1000,
-      clientId: `va3${md5}`,
+      clientId: mqttClientId || `va3${md5}`,
       rejectUnauthorized: false,
       will: {
         topic: `${this._baseTopic}/__agentInfo__`,


### PR DESCRIPTION
Simple and straightforward implementation of the possibility of setting a mqtt client id in VrpcAgent.serve

closes #56 