### PR TITLE
Fix ignored failures of MQTT subscriptions and now emit an error event (#58)

### DIFF
--- a/tests/agent/vrpc-agent.spec.js
+++ b/tests/agent/vrpc-agent.spec.js
@@ -97,6 +97,80 @@ describe('vrpc-agent', () => {
         await agent.end()
       })
     })
+
+    context('when dealing with failed subscribe calls', () => {
+      const mockSubscribeFunction = (topic, options, callback) => {
+        const topicArray = Array.isArray(topic) ? topic : [topic]
+        const resultArray = topicArray.map(x => {
+          return {
+            topic: x,
+            qos:
+              options.outputQos === undefined ? options.qos : options.outputQos
+          }
+        })
+        callback(null, resultArray)
+      }
+      const agent = new VrpcAgent({
+        username: 'does',
+        password: 'not exist',
+        bestEffort: false
+      })
+      // Install a mock mqtt client object
+      agent._client = {
+        subscribe: mockSubscribeFunction
+      }
+      it('should correctly report error on subscribe with qos=128', () => {
+        const errorSpy = sinon.spy()
+        agent.on('error', errorSpy)
+
+        agent._mqttSubscribe('foo')
+        assert(errorSpy.notCalled) // all fine
+
+        agent._mqttSubscribe(['foo', 'bar'])
+        assert(errorSpy.notCalled) // all fine
+
+        // now mock a failed subscription
+        agent._mqttSubscribe('foo', { outputQos: 128 })
+        assert.strictEqual(errorSpy.args[0][0].code, 'SUBSCRIBE_FAILED')
+        assert.strictEqual(
+          errorSpy.args[0][0].message,
+          'Could not subscribe all 1 topic(s) but got error qos=128 on following 1 topic(s): foo'
+        )
+
+        agent.off('error', errorSpy)
+      })
+      it('should correctly report error on subscribe where qos=0 is returned', () => {
+        const errorSpy = sinon.spy()
+        agent.on('error', errorSpy)
+
+        // and now mock a subscription with reduced qos
+        agent._mqttSubscribe('foo', { outputQos: 0 })
+        assert.strictEqual(errorSpy.args[0][0].code, 'SUBSCRIBE_REDUCED_QOS')
+        assert.strictEqual(
+          errorSpy.args[0][0].message,
+          'Could not subscribe all 1 topic(s) at desired qos=1 but got reduced qos on following 1 topic(s): [{"topic":"foo","qos":0}]'
+        )
+
+        agent.off('error', errorSpy)
+      })
+      it('should correctly not report error on subscribe with qos=0 if bestEffort=true', () => {
+        const bestEffortAgent = new VrpcAgent({
+          username: 'does',
+          password: 'not exist',
+          bestEffort: true // now with "true" here
+        })
+        // Install a mock mqtt client object
+        bestEffortAgent._client = {
+          subscribe: mockSubscribeFunction
+        }
+        const errorSpy = sinon.spy()
+        bestEffortAgent.on('error', errorSpy)
+
+        // and now mock a subscription with qos=0 but this is also intended
+        bestEffortAgent._mqttSubscribe('foo', { outputQos: 0 })
+        assert(errorSpy.notCalled) // all fine
+      })
+    })
   })
   /**************************
    * signalling client gone *

--- a/vrpc/VrpcClient.js
+++ b/vrpc/VrpcClient.js
@@ -715,7 +715,7 @@ class VrpcClient extends EventEmitter {
       (err, granted) => {
         if (err) {
           this._log.warn(
-            `Could not subscribe to topic: ${topic} because: ${err.message}`
+            `Could not subscribe to topic(s): '${topic}', because: ${err.message}`
           )
           if (err.message === 'client disconnecting') {
             // Workaround for an already reported bug in MQTT.js (#1284)
@@ -724,6 +724,35 @@ class VrpcClient extends EventEmitter {
             this._client.end(true, {}, () => this._client.reconnect())
           }
         } else {
+          const topicArray = Array.isArray(topic) ? topic : [topic]
+          const erroneousGranted = granted
+            .filter(x => x.qos === 128)
+            .map(x => x.topic)
+          if (erroneousGranted.length > 0) {
+            err = new Error(
+              `Could not subscribe all ${topicArray.length} topic(s) but got error qos=128 on following ${erroneousGranted.length} topic(s): ${erroneousGranted}`
+            )
+            err.code = 'SUBSCRIBE_FAILED'
+            err.subscribeOptions = options
+            this._log.error(err)
+            this.emit('error', err)
+          }
+          const reducedQos = granted.filter(x => x.qos < this._qos)
+          if (reducedQos.length > 0) {
+            err = new Error(
+              `Could not subscribe all ${
+                topicArray.length
+              } topic(s) at desired qos=${
+                this._qos
+              } but got reduced qos on following ${
+                reducedQos.length
+              } topic(s): ${JSON.stringify(reducedQos)}`
+            )
+            err.code = 'SUBSCRIBE_REDUCED_QOS'
+            err.subscribeOptions = options
+            this._log.warn(err)
+            this.emit('error', err)
+          }
           if (granted.length === 0) {
             this._log.debug(`Already subscribed to: ${topic}`)
           }


### PR DESCRIPTION
# Description

Identify failed mqtt subscriptions, add clear log messages, and emit a
suitable error event.

The important change is the newly added error treatment in the MQTT
subscribe call, where the returned granted argument might list topics
with qos=128 which means those topics have not been subscribed. This is
a serious problem on which the application code must be able to react.

## How has this been tested?

Unittest with mocked MQTT calls have been added, so that each expected error event is checked by the unittest.

closes #58
