### PR TITLE
Wrapping callback execution by try/catch to avoid unhandled exception

### DIFF
--- a/vrpc/VrpcNative.js
+++ b/vrpc/VrpcNative.js
@@ -111,7 +111,13 @@ class VrpcNative {
             const id = `__f__${context}-${functionName}-${i}-${invokeId++ %
               Number.MAX_SAFE_INTEGER}`
             wrapped.push(id)
-            eventEmitter.once(id, a => x.apply(null, a))
+            eventEmitter.once(id, a => {
+              try {
+                x.apply(null, a) // This is the actual function call
+              } catch (err) {
+                console.error('VrpcNative:118: Failed to execute callback:', err)
+              }
+            })
           }
         } else if (VrpcNative._isEmitter(x)) {
           const { emitter, event } = x


### PR DESCRIPTION
# Description
When calling a native function with a callback, and that callback throws an exception, the whole runtime crashes. Hence we better wrap the call to the callback into try/catch to avoid the overall crash.

## How has this been tested?
Needs setting up a native function that receives a function pointer, to which the javascript call then provides a callback that in turn throws an exception.

closes #52 
